### PR TITLE
Allow images from minecraft resources in Button

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: EasyForms
 main: Frago9876543210\EasyForms\EasyForms
-version: 1.0.3
+version: 1.1.0
 api: 4.0.0
 extensions: ds

--- a/src/Frago9876543210/EasyForms/elements/menu/Button.php
+++ b/src/Frago9876543210/EasyForms/elements/menu/Button.php
@@ -18,6 +18,7 @@ class Button extends Element{
 	 * Button constructor.
 	 * @param string      $text
 	 * @param null|string $image
+	 * @param bool $isUrl
 	 */
 	public function __construct(string $text, ?string $image = null, bool $isUrl = true){
 		parent::__construct($text);

--- a/src/Frago9876543210/EasyForms/elements/menu/Button.php
+++ b/src/Frago9876543210/EasyForms/elements/menu/Button.php
@@ -11,14 +11,18 @@ class Button extends Element{
 	/** @var null|string */
 	protected $image;
 
+	/** @var string */
+	protected $imageType;
+
 	/**
 	 * Button constructor.
 	 * @param string      $text
 	 * @param null|string $image
 	 */
-	public function __construct(string $text, ?string $image = null){
+	public function __construct(string $text, ?string $image = null, bool $isUrl = true){
 		parent::__construct($text);
 		$this->image = $image;
+		$this->imageType = $isUrl ? "url" : "path";
 	}
 
 	/**
@@ -35,7 +39,7 @@ class Button extends Element{
 		$data = ["text" => $this->text];
 		if($this->hasImage()){
 			$data["image"] = [
-				"type" => "url",
+				"type" => $this->imageType,
 				"data" => $this->image
 			];
 		}
@@ -47,5 +51,12 @@ class Button extends Element{
 	 */
 	public function hasImage() : bool{
 		return $this->image !== null;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getImageType() : string{
+		return $this->imageType;
 	}
 }


### PR DESCRIPTION
The image type in Button is set to url and can't be changed, this is undesirable when one intends to use images from a resourcepack.

This pr adds an additional parameter to Button::__construct() with a default value which defaults to url in order to preserve backwards compatibility.

Furthermore this pr bumps the plugin version up in the minor section.